### PR TITLE
Add common_ancestor function

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ We so far only support calculating a few metrics on trees, but will gradually be
 ```julia
 
 julia> species = getleaves(tree)[[2, 5, 8, 12, 22]];  # take 5 tips from the phylogeny (or use names)
-julia> common_ancestor(tree, species)                 # Identify the MRCA (Most Recent Common Ancestor)
+julia> mrca(tree, species)                 # Identify the MRCA (Most Recent Common Ancestor)
 LinkNode Node 65, an internal node with 1 inbound and 2 outbound connections (branches 999 and 61, 62)
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ Dict{String,Any} with 1 entry:
   "lnP" => 1.0
 ```
 
+### Calculating metrics
+
+We so far only support calculating a few metrics on trees, but will gradually be added. Open an issue with a request!
+
+```julia
+
+julia> species = getleaves(tree)[[2, 5, 8, 12, 22]];  # take 5 tip from the phylogeny - a vector of tip names can als be used
+julia> common_ancestor(tree, species)                 # Identify the MRCA (Most Recent Common Ancestor) for the 5 species
+LinkNode Node 65, an internal node with 1 inbound and 2 outbound connections (branches 999 and 61, 62)
+```
+
 ### R interface
 
 And while we wait for me (or kind [contributors][pr-url]!) to fill out

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ We so far only support calculating a few metrics on trees, but will gradually be
 
 ```julia
 
-julia> species = getleaves(tree)[[2, 5, 8, 12, 22]];  # take 5 tip from the phylogeny - a vector of tip names can als be used
-julia> common_ancestor(tree, species)                 # Identify the MRCA (Most Recent Common Ancestor) for the 5 species
+julia> species = getleaves(tree)[[2, 5, 8, 12, 22]];  # take 5 tips from the phylogeny (or use names)
+julia> common_ancestor(tree, species)                 # Identify the MRCA (Most Recent Common Ancestor)
 LinkNode Node 65, an internal node with 1 inbound and 2 outbound connections (branches 999 and 61, 62)
 ```
 

--- a/src/Phylo.jl
+++ b/src/Phylo.jl
@@ -181,6 +181,10 @@ export droptips!, keeptips!
 # Plot recipes
 include("plot.jl")
 
+# Metrics from the tree
+include("metrics.jl")
+export common_ancestor
+
 # Path into package
 path(path...; dir::String = "test") = joinpath(@__DIR__, "..", dir, path...)
 

--- a/src/Phylo.jl
+++ b/src/Phylo.jl
@@ -183,7 +183,7 @@ include("plot.jl")
 
 # Metrics from the tree
 include("metrics.jl")
-export common_ancestor
+export mrca
 
 # Path into package
 path(path...; dir::String = "test") = joinpath(@__DIR__, "..", dir, path...)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -1,4 +1,4 @@
-function common_ancestor(tree, target)
+function mrca(tree, target)
     ancestors = getancestors(tree, first(target))
     ranks = Dict(j => i for (i,j) in enumerate(ancestors))
     checked = Set(ancestors)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -1,0 +1,14 @@
+function common_ancestor(tree, target)
+    ancestors = getancestors(tree, first(target))
+    ranks = Dict(j => i for (i,j) in enumerate(ancestors))
+    checked = Set(ancestors)
+    oldest = 1
+    for species in target
+        while !(species ∈ checked)
+            push!(checked, species)
+            species = getparent(tree, species)
+        end
+        oldest = max(oldest, get(ranks, species, 0))
+    end
+    ancestors[oldest]
+end

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -5,31 +5,32 @@ using Test
 
 @testset "Metrics" begin
     trees = open(parsenexus, Phylo.path("H1N1.trees"))
+    tree1, tree2 = trees["TREE1"], trees["TREE2"]
     species = ["H1N1_A_PUERTORICO_8_1934", "H1N1_A_BRAZIL_11_1978"];
-    mrca1 = mrca(trees["TREE1"], species)
+    mrca1 = mrca(tree1, species)
 
     # MRCA should be the root
-    @test mrca1 == getnodename(tree["TREE1"], getroot(tree["TREE1"]))
-    nodes = getnodenames(tree["TREE1"])
-    desc1 = getdescendants(tree["TREE1"], mrca1)
+    @test mrca1 == getnodename(tree1, getroot(tree1))
+    nodes = getnodenames(tree1)
+    desc1 = getdescendants(tree1, mrca1)
 
     # MRCA + descendants is whole tree
     @test all(sort(nodes) .== sort(desc1 ∪ [mrca1]))
-    leaves = getleafnames(tree["TREE1"])
+    leaves = getleafnames(tree1)
     leaves1 = sort(leaves ∩ desc1)
 
     # All leaves are in descendants
     @test length(leaves1) == length(leaves)
 
     # All leaves are the same in both trees
-    mrca2 = mrca(trees["TREE2"], reverse(species))
-    leaves2 = sort(leaves ∩ getdescendants(tree["TREE2"], mrca2))
+    mrca2 = mrca(tree2, reverse(species))
+    leaves2 = sort(leaves ∩ getdescendants(tree2, mrca2))
     @test all(leaves1 .== leaves2)
 
     # MRCA for Sendai strains has 8 descendants, including Fukuoka
     desendais =
-        getdescendants(tree["TREE1"],
-                       mrca(tree["TREE1"],
+        getdescendants(tree1,
+                       mrca(tree1,
                                        filter(x -> contains(x, "SENDAI"),
                                        leaves)))
     @test length(desendais) == 8

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -6,7 +6,7 @@ using Test
 @testset "Metrics" begin
     trees = open(parsenexus, Phylo.path("H1N1.trees"))
     species = ["H1N1_A_PUERTORICO_8_1934", "H1N1_A_BRAZIL_11_1978"];
-    mrca1 = common_ancestor(trees["TREE1"], species)
+    mrca1 = mrca(trees["TREE1"], species)
 
     # MRCA should be the root
     @test mrca1 == getnodename(tree["TREE1"], getroot(tree["TREE1"]))
@@ -22,14 +22,14 @@ using Test
     @test length(leaves1) == length(leaves)
 
     # All leaves are the same in both trees
-    mrca2 = common_ancestor(trees["TREE2"], reverse(species))
+    mrca2 = mrca(trees["TREE2"], reverse(species))
     leaves2 = sort(leaves ∩ getdescendants(tree["TREE2"], mrca2))
     @test all(leaves1 .== leaves2)
 
     # MRCA for Sendai strains has 8 descendants, including Fukuoka
     desendais =
         getdescendants(tree["TREE1"],
-                       common_ancestor(tree["TREE1"],
+                       mrca(tree["TREE1"],
                                        filter(x -> contains(x, "SENDAI"),
                                        leaves)))
     @test length(desendais) == 8

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -1,0 +1,10 @@
+module TestMetrics
+
+using Phylo
+using Test
+
+@testset "Metrics" begin
+    species = getleaves(tree)[[2, 5, 8, 12, 22]];
+    mrca = common_ancestor(tree, species)
+    @test getnodename(tree, mrca) == "Node 65"
+end

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -8,3 +8,5 @@ using Test
     mrca = common_ancestor(tree, species)
     @test getnodename(tree, mrca) == "Node 65"
 end
+
+end

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -4,10 +4,36 @@ using Phylo
 using Test
 
 @testset "Metrics" begin
-    tree = open(parsenewick, Phylo.path("H1N1.newick"))
-    species = getleaves(tree)[[2, 5, 8, 12, 22]];
-    mrca = common_ancestor(tree, species)
-    @test getnodename(tree, mrca) == "Node 65"
+    trees = open(parsenexus, Phylo.path("H1N1.trees"))
+    species = ["H1N1_A_PUERTORICO_8_1934", "H1N1_A_BRAZIL_11_1978"];
+    mrca1 = common_ancestor(trees["TREE1"], species)
+
+    # MRCA should be the root
+    @test mrca1 == getnodename(tree["TREE1"], getroot(tree["TREE1"]))
+    nodes = getnodenames(tree["TREE1"])
+    desc1 = getdescendants(tree["TREE1"], mrca1)
+
+    # MRCA + descendants is whole tree
+    @test all(sort(nodes) .== sort(desc1 ∪ [mrca1]))
+    leaves = getleafnames(tree["TREE1"])
+    leaves1 = sort(leaves ∩ desc1)
+
+    # All leaves are in descendants
+    @test length(leaves1) == length(leaves)
+
+    # All leaves are the same in both trees
+    mrca2 = common_ancestor(trees["TREE2"], reverse(species))
+    leaves2 = sort(leaves ∩ getdescendants(tree["TREE2"], mrca2))
+    @test all(leaves1 .== leaves2)
+
+    # MRCA for Sendai strains has 8 descendants, including Fukuoka
+    desendais =
+        getdescendants(tree["TREE1"],
+                       common_ancestor(tree["TREE1"],
+                                       filter(x -> contains(x, "SENDAI"),
+                                       leaves)))
+    @test length(desendais) == 8
+    @test length(filter(x -> contains(x, "FUKUOKA"), desendais)) == 1
 end
 
 end

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -4,6 +4,7 @@ using Phylo
 using Test
 
 @testset "Metrics" begin
+    tree = open(parsenewick, Phylo.path("H1N1.newick"))
     species = getleaves(tree)[[2, 5, 8, 12, 22]];
     mrca = common_ancestor(tree, species)
     @test getnodename(tree, mrca) == "Node 65"


### PR DESCRIPTION
Adds a new metrics.jl file which currently only has a function to identify the most recent common ancestor. See discusion at #40. 

@tpoisot I've branched off your master branch, is that OK? 
@isaacovercast would you mind testing?